### PR TITLE
feat: publish the live campaign figures in the tagline JSON

### DIFF
--- a/.github/workflows/update-campaign-figures.yml
+++ b/.github/workflows/update-campaign-figures.yml
@@ -1,0 +1,59 @@
+name: Update campaign figures
+
+# Reads the live donation figures off the campaign page and commits them into
+# the tagline JSON files, so the app's donation card can show a number that
+# moves instead of only an adjective.
+#
+# The app caches the tagline feed for a day, so daily is as fresh as it can
+# usefully be. Running more often would only add requests for a total that
+# moves by a few euros a day.
+#
+# Safe to merge before anything reads the fields: apps ignore JSON keys they do
+# not know, and the script refuses to write anything that fails its checks, so
+# the worst case is that the figures stay as they were.
+
+on:
+  schedule:
+    # 06:17 UTC daily. GitHub treats cron as best effort and can run it late.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-campaign-figures
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Read the campaign figures and update the tagline files
+        run: python tools/update_campaign_figures.py
+
+      - name: Validate tagline JSON files
+        run: python tests/validate_tagline_json.py
+
+      - name: Commit the new figures, if any changed
+        run: |
+          if git diff --quiet -- prod/tagline; then
+            echo "No change in the figures, nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add prod/tagline/android/main.json \
+                  prod/tagline/ios/main.json \
+                  prod/tagline/web/main.json
+          git commit -m "chore: update the donation campaign figures"
+          git push

--- a/.github/workflows/validate-tagline.yml
+++ b/.github/workflows/validate-tagline.yml
@@ -6,11 +6,15 @@ on:
       - 'prod/tagline/android/main.json'
       - 'prod/tagline/ios/main.json'
       - 'prod/tagline/web/main.json'
+      - 'tools/update_campaign_figures.py'
+      - 'tests/**'
   pull_request:
     paths:
       - 'prod/tagline/android/main.json'
       - 'prod/tagline/ios/main.json'
       - 'prod/tagline/web/main.json'
+      - 'tools/update_campaign_figures.py'
+      - 'tests/**'
 
 permissions:
   contents: read
@@ -30,3 +34,6 @@ jobs:
 
     - name: Validate tagline JSON files
       run: python tests/validate_tagline_json.py
+
+    - name: Check the campaign figure updater refuses bad input
+      run: python tests/test_update_campaign_figures.py

--- a/prod/tagline/README.md
+++ b/prod/tagline/README.md
@@ -67,7 +67,9 @@ JSON
   ```bash
   python tools/update_campaign_figures.py --dry-run
   ```
-  It refuses to write implausible numbers, so a failed run leaves the previous figures in place on purpose. A stale number is better than a wrong one.
+  It refuses to write a number it cannot justify, so a failed run leaves the previous figures in place on purpose. A stale number is better than a wrong one. Concretely it refuses when: the page markup changed, the currency is unknown, a figure will not parse, the total collapsed or multiplied since last time, or **our own arithmetic disagrees by more than two points with the percentage Donorbox itself draws in its progress bar**. That last one is the useful check: it compares our reading against the campaign's own.
+
+  `python tests/test_update_campaign_figures.py` exercises those refusals without touching the network.
 - Editing them by hand is still fine, for example if the campaign moves to a different platform. The workflow will simply overwrite them on its next run.
 - Removing any one of the three makes the app fall back to a plain card with no meter, so they are safe to delete.
 

--- a/prod/tagline/README.md
+++ b/prod/tagline/README.md
@@ -60,6 +60,17 @@ JSON
 - Repeat the changes in the [`prod/tagline/ios/main.json`](https://github.com/openfoodfacts/smooth-app_assets/prod/tagline/ios/main.json) file for the iOS app to keep the behavior consistent across platforms.
 - Also repeat the changes in the [`prod/tagline/web/main.json`](https://github.com/openfoodfacts/smooth-app_assets/prod/tagline/web/main.json) file for web applications (openfoodfacts-explorer and openfoodfacts-server) to maintain consistency across all platforms.
 
+### 4b. Fundraising campaigns: the figures are filled in automatically
+- A campaign can carry three optional fields on its news item, next to `min_launches`: `raised`, `goal` and `currency` (an ISO code such as `EUR`). When all three are present, the app draws a progress meter on the card showing how the campaign is doing.
+- **You do not normally edit these by hand.** The [`Update campaign figures`](https://github.com/openfoodfacts/smooth-app_assets/actions/workflows/update-campaign-figures.yml) workflow runs once a day, reads the figures from the Donorbox campaign page, and commits them. You can also trigger it yourself from the Actions tab.
+- If the figures ever look wrong or stale, run the script locally to see what it reads without changing anything:
+  ```bash
+  python tools/update_campaign_figures.py --dry-run
+  ```
+  It refuses to write implausible numbers, so a failed run leaves the previous figures in place on purpose. A stale number is better than a wrong one.
+- Editing them by hand is still fine, for example if the campaign moves to a different platform. The workflow will simply overwrite them on its next run.
+- Removing any one of the three makes the app fall back to a plain card with no meter, so they are safe to delete.
+
 ### 5. Validate the JSON
 - Use a JSON validator (e.g., [jsonlint.com](https://jsonlint.com)) to ensure there are no syntax errors. Note that we will soon have automated JSON linting built into this repository.
 

--- a/prod/tagline/android/main.json
+++ b/prod/tagline/android/main.json
@@ -264,8 +264,11 @@
       "url": "https://prices.openfoodfacts.org/challenge"
     },
     "donation_campaign_2026": {
+      "currency": "EUR",
       "end_date": "2027-01-31 23:59:59",
+      "goal": 170000.0,
       "min_launches": 5,
+      "raised": 44155.91,
       "start_date": "2025-10-25 00:00:00",
       "translations": {
         "ar": {

--- a/prod/tagline/ios/main.json
+++ b/prod/tagline/ios/main.json
@@ -264,8 +264,11 @@
       "url": "https://prices.openfoodfacts.org/challenge"
     },
     "donation_campaign_2026": {
+      "currency": "EUR",
       "end_date": "2027-01-31 23:59:59",
+      "goal": 170000.0,
       "min_launches": 5,
+      "raised": 44155.91,
       "start_date": "2025-10-25 00:00:00",
       "translations": {
         "ar": {

--- a/prod/tagline/web/main.json
+++ b/prod/tagline/web/main.json
@@ -269,8 +269,11 @@
       "url": "https://prices.openfoodfacts.org/challenge"
     },
     "donation_campaign_2026": {
+      "currency": "EUR",
       "end_date": "2027-01-31 23:59:59",
+      "goal": 170000.0,
       "min_launches": 5,
+      "raised": 44155.91,
       "start_date": "2025-10-25 00:00:00",
       "translations": {
         "ar": {

--- a/tests/test_update_campaign_figures.py
+++ b/tests/test_update_campaign_figures.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Check that the campaign figure updater refuses bad input instead of publishing it.
+
+The point of these checks is the failure paths, not the happy one: the updater
+runs unattended on a schedule against a page nobody here controls, so what
+matters is that a changed page, a localised number or an implausible figure
+leaves the tagline files exactly as they were.
+
+Run with: python tests/test_update_campaign_figures.py
+"""
+
+import json
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from tools.update_campaign_figures import (  # noqa: E402
+    FigureError,
+    NEWS_ID,
+    parse_amount,
+    plan_update,
+    scrape_figures,
+    validate_figures,
+)
+
+PAGE = '''
+<div class="campaign">
+  <p class="bold" id="total-raised">44.155,91 €</p>
+  <p class="bold">170.000 €</p>
+</div>
+'''
+
+
+def expect_error(description, function, *arguments):
+    try:
+        function(*arguments)
+    except FigureError:
+        return
+    raise AssertionError(f'{description} should have raised FigureError')
+
+
+def test_scrapes_the_page():
+    figures = scrape_figures(PAGE)
+    assert figures == {'currency': 'EUR', 'goal': 170000.0, 'raised': 44155.91}, figures
+
+
+def test_reads_both_separator_conventions():
+    assert parse_amount('44.155,91 €') == 44155.91
+    assert parse_amount('$44,155.91') == 44155.91
+    assert parse_amount('170.000 €') == 170000.0
+    assert parse_amount('£170,000') == 170000.0
+    # One separator, three digits after it, is thousands and not a fraction.
+    assert parse_amount('1.500') == 1500.0
+
+
+def test_refuses_a_page_it_cannot_read():
+    expect_error('markup without #total-raised', scrape_figures, '<p>nothing here</p>')
+    expect_error(
+        'a raised figure with no goal beside it',
+        scrape_figures,
+        '<p class="bold" id="total-raised">44.155,91 €</p>',
+    )
+    expect_error('a currency we do not know', scrape_figures, PAGE.replace('€', '¤'))
+    expect_error('text with no digits at all', parse_amount, 'soon')
+
+
+def test_refuses_implausible_figures():
+    expect_error(
+        'a raised far above the goal',
+        validate_figures,
+        {'raised': 900000.0, 'goal': 170000.0, 'currency': 'EUR'},
+    )
+    expect_error(
+        'a zero goal',
+        validate_figures,
+        {'raised': 100.0, 'goal': 0.0, 'currency': 'EUR'},
+    )
+    # A total that collapses is a bad parse, not a day of refunds.
+    expect_error(
+        'a raised that dropped by more than 10%',
+        validate_figures,
+        {'raised': 30000.0, 'goal': 170000.0, 'currency': 'EUR'},
+        44155.91,
+    )
+    # A small drop is plausible and must still go through.
+    validate_figures({'raised': 43000.0, 'goal': 170000.0, 'currency': 'EUR'}, 44155.91)
+
+
+def test_planning_writes_nothing():
+    figures = {'currency': 'EUR', 'goal': 170000.0, 'raised': 44155.91}
+    with tempfile.TemporaryDirectory() as directory:
+        path = pathlib.Path(directory) / 'main.json'
+        original = json.dumps({'news': {NEWS_ID: {'url': 'https://example.org'}}})
+        path.write_text(original, encoding='utf-8')
+
+        content = plan_update(str(path), figures)
+
+        assert content is not None
+        assert json.loads(content)['news'][NEWS_ID]['raised'] == 44155.91
+        # The file itself is untouched until every file has been planned.
+        assert path.read_text(encoding='utf-8') == original
+
+
+def test_planning_reports_a_file_it_cannot_use():
+    figures = {'currency': 'EUR', 'goal': 170000.0, 'raised': 44155.91}
+    with tempfile.TemporaryDirectory() as directory:
+        missing_item = pathlib.Path(directory) / 'no-item.json'
+        missing_item.write_text('{"news": {}}', encoding='utf-8')
+        expect_error('a file without the news item', plan_update, str(missing_item), figures)
+
+        broken = pathlib.Path(directory) / 'broken.json'
+        broken.write_text('{not json', encoding='utf-8')
+        expect_error('a file that is not JSON', plan_update, str(broken), figures)
+
+        expect_error(
+            'a file that does not exist',
+            plan_update,
+            str(pathlib.Path(directory) / 'absent.json'),
+            figures,
+        )
+
+
+def main():
+    tests = [value for name, value in sorted(globals().items())
+             if name.startswith('test_') and callable(value)]
+    for test in tests:
+        test()
+        print(f'ok  {test.__name__}')
+    print(f'{len(tests)} checks passed')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_update_campaign_figures.py
+++ b/tests/test_update_campaign_figures.py
@@ -115,10 +115,25 @@ def test_refuses_figures_the_page_itself_contradicts():
     validate_figures({'raised': 44155.91, 'goal': 170000.0, 'currency': 'EUR'}, None, 25.0)
 
 
-def test_ignores_a_meter_clamped_at_full():
+def test_reads_a_clamped_meter_as_the_goal_being_reached():
     # An over-funded campaign draws 100% whatever the real ratio, so the bar
-    # states nothing and must not be used to refuse a legitimate figure.
+    # states no ratio and must not refuse a legitimate figure.
     validate_figures({'raised': 200000.0, 'goal': 170000.0, 'currency': 'EUR'}, None, 100.0)
+
+    # It does still say the goal was reached. Skipping the check outright here
+    # would wave through a misparsed goal at the one moment nothing else can
+    # catch one, since `raised > goal * 3` only guards a misparsed raised.
+    expect_error(
+        'a full meter under a goal we never reached',
+        validate_figures,
+        {'raised': 175000.0, 'goal': 26170000.0, 'currency': 'EUR'},
+        174000.0,
+        100.0,
+    )
+
+    # A hair short of the goal is within the same tolerance the other branch
+    # gets, in case the page ever rounds the width up instead of flooring it.
+    validate_figures({'raised': 169500.0, 'goal': 170000.0, 'currency': 'EUR'}, None, 100.0)
 
 
 def test_refuses_implausible_figures():

--- a/tests/test_update_campaign_figures.py
+++ b/tests/test_update_campaign_figures.py
@@ -20,15 +20,20 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 from tools.update_campaign_figures import (  # noqa: E402
     FigureError,
     NEWS_ID,
+    apply_updates,
     parse_amount,
     plan_update,
     scrape_figures,
+    scrape_page_percent,
     validate_figures,
 )
 
+# Shaped like the real block: three bold paragraphs, only one of them the goal.
 PAGE = '''
+<style> .progress .meter { width: 26%; } </style>
 <div class="campaign">
   <p class="bold" id="total-raised">44.155,91 €</p>
+  <p id="paid-count" class="bold">517</p>
   <p class="bold">170.000 €</p>
 </div>
 '''
@@ -67,6 +72,25 @@ def test_refuses_a_page_it_cannot_read():
     expect_error('text with no digits at all', parse_amount, 'soon')
 
 
+def test_reads_the_percentage_the_page_draws():
+    assert scrape_page_percent(PAGE) == 26.0
+    assert scrape_page_percent('<p>no bar here</p>') is None
+
+
+def test_refuses_figures_the_page_itself_contradicts():
+    # Two numbers in one text node concatenate into a plausible-looking goal,
+    # and only the page's own percentage catches it.
+    expect_error(
+        'a goal that disagrees with the drawn percentage',
+        validate_figures,
+        {'raised': 44155.91, 'goal': 26170000.0, 'currency': 'EUR'},
+        None,
+        26.0,
+    )
+    # The real figures agree with it, to well inside the tolerance.
+    validate_figures({'raised': 44155.91, 'goal': 170000.0, 'currency': 'EUR'}, None, 26.0)
+
+
 def test_refuses_implausible_figures():
     expect_error(
         'a raised far above the goal',
@@ -83,6 +107,14 @@ def test_refuses_implausible_figures():
         'a raised that dropped by more than 10%',
         validate_figures,
         {'raised': 30000.0, 'goal': 170000.0, 'currency': 'EUR'},
+        44155.91,
+    )
+    # A total that multiplies overnight is a misparse, not a good day. The app
+    # renders the unclamped percentage, so this would read "294%" on the card.
+    expect_error(
+        'a raised that jumped past 3x',
+        validate_figures,
+        {'raised': 500000.0, 'goal': 170000.0, 'currency': 'EUR'},
         44155.91,
     )
     # A small drop is plausible and must still go through.
@@ -115,12 +147,64 @@ def test_planning_reports_a_file_it_cannot_use():
         broken.write_text('{not json', encoding='utf-8')
         expect_error('a file that is not JSON', plan_update, str(broken), figures)
 
+        # Valid JSON, but not the shape we index into.
+        for name, content in (('list.json', '[]'), ('scalar.json', '5'),
+                              ('news-list.json', '{"news": []}')):
+            wrong_shape = pathlib.Path(directory) / name
+            wrong_shape.write_text(content, encoding='utf-8')
+            expect_error(f'{content} at the top level', plan_update,
+                         str(wrong_shape), figures)
+
         expect_error(
             'a file that does not exist',
             plan_update,
             str(pathlib.Path(directory) / 'absent.json'),
             figures,
         )
+
+
+def test_a_bad_third_file_leaves_the_first_two_untouched():
+    """The behaviour the maintainer asked about, end to end.
+
+    Planning all three before writing any is what makes this pass. Writing each
+    file as it is planned would leave the first two already changed.
+    """
+    figures = {'currency': 'EUR', 'goal': 170000.0, 'raised': 44155.91}
+    good = json.dumps({'news': {NEWS_ID: {'url': 'https://example.org'}}})
+
+    with tempfile.TemporaryDirectory() as directory:
+        paths = []
+        for name in ('android.json', 'ios.json'):
+            path = pathlib.Path(directory) / name
+            path.write_text(good, encoding='utf-8')
+            paths.append(str(path))
+        broken = pathlib.Path(directory) / 'web.json'
+        broken.write_text('{not json', encoding='utf-8')
+        paths.append(str(broken))
+
+        try:
+            {path: plan_update(path, figures) for path in paths}
+        except FigureError:
+            pass
+        else:
+            raise AssertionError('the broken third file should have been refused')
+
+        for path in paths[:2]:
+            assert pathlib.Path(path).read_text(encoding='utf-8') == good, path
+
+
+def test_dry_run_writes_nothing():
+    original = json.dumps({'news': {NEWS_ID: {'url': 'https://example.org'}}})
+    with tempfile.TemporaryDirectory() as directory:
+        path = pathlib.Path(directory) / 'main.json'
+        path.write_text(original, encoding='utf-8')
+        plans = {str(path): 'REPLACED'}
+
+        assert apply_updates(plans, dry_run=True) == [str(path)]
+        assert path.read_text(encoding='utf-8') == original
+
+        assert apply_updates(plans) == [str(path)]
+        assert path.read_text(encoding='utf-8') == 'REPLACED'
 
 
 def main():

--- a/tests/test_update_campaign_figures.py
+++ b/tests/test_update_campaign_figures.py
@@ -10,7 +10,9 @@ leaves the tagline files exactly as they were.
 Run with: python tests/test_update_campaign_figures.py
 """
 
+import io
 import json
+import os
 import pathlib
 import sys
 import tempfile
@@ -20,23 +22,39 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 from tools.update_campaign_figures import (  # noqa: E402
     FigureError,
     NEWS_ID,
+    REPO_ROOT,
+    TAGLINE_FILES,
     apply_updates,
+    campaign_is_published,
     parse_amount,
     plan_update,
+    previous_raised,
+    publish,
     scrape_figures,
     scrape_page_percent,
     validate_figures,
 )
 
-# Shaped like the real block: three bold paragraphs, only one of them the goal.
+# Shaped like the real block: three bold paragraphs, only one of them the goal,
+# and the drawn width floored to 25 the way Donorbox floors it against 25.97%.
 PAGE = '''
-<style> .progress .meter { width: 26%; } </style>
+<style> .progress .meter { width: 25%; } </style>
 <div class="campaign">
   <p class="bold" id="total-raised">44.155,91 €</p>
   <p id="paid-count" class="bold">517</p>
   <p class="bold">170.000 €</p>
 </div>
 '''
+
+
+def a_tagline_file(directory, name, raised=None):
+    """Write a minimal tagline file and return its path."""
+    item = {'url': 'https://example.org'}
+    if raised is not None:
+        item['raised'] = raised
+    path = pathlib.Path(directory) / name
+    path.write_text(json.dumps({'news': {NEWS_ID: item}}), encoding='utf-8')
+    return str(path)
 
 
 def expect_error(description, function, *arguments):
@@ -73,8 +91,13 @@ def test_refuses_a_page_it_cannot_read():
 
 
 def test_reads_the_percentage_the_page_draws():
-    assert scrape_page_percent(PAGE) == 26.0
-    assert scrape_page_percent('<p>no bar here</p>') is None
+    assert scrape_page_percent(PAGE) == 25.0
+
+
+def test_refuses_a_page_that_draws_no_progress_bar():
+    # Failing closed matters here: this number exists to catch a page whose
+    # markup moved, so a missing bar is the case it is for, not an excuse.
+    expect_error('a page with no meter', scrape_page_percent, '<p>no bar here</p>')
 
 
 def test_refuses_figures_the_page_itself_contradicts():
@@ -85,10 +108,17 @@ def test_refuses_figures_the_page_itself_contradicts():
         validate_figures,
         {'raised': 44155.91, 'goal': 26170000.0, 'currency': 'EUR'},
         None,
-        26.0,
+        25.0,
     )
-    # The real figures agree with it, to well inside the tolerance.
-    validate_figures({'raised': 44155.91, 'goal': 170000.0, 'currency': 'EUR'}, None, 26.0)
+    # The real figures agree with it, inside the tolerance Donorbox's flooring
+    # already eats about half of: 25.97 computed against a drawn 25.
+    validate_figures({'raised': 44155.91, 'goal': 170000.0, 'currency': 'EUR'}, None, 25.0)
+
+
+def test_ignores_a_meter_clamped_at_full():
+    # An over-funded campaign draws 100% whatever the real ratio, so the bar
+    # states nothing and must not be used to refuse a legitimate figure.
+    validate_figures({'raised': 200000.0, 'goal': 170000.0, 'currency': 'EUR'}, None, 100.0)
 
 
 def test_refuses_implausible_figures():
@@ -109,16 +139,20 @@ def test_refuses_implausible_figures():
         {'raised': 30000.0, 'goal': 170000.0, 'currency': 'EUR'},
         44155.91,
     )
-    # A total that multiplies overnight is a misparse, not a good day. The app
-    # renders the unclamped percentage, so this would read "294%" on the card.
+    # Raising more than the whole goal in one run is a misparse, not a good day.
+    # The app renders the unclamped percentage, so this would read "294%".
     expect_error(
-        'a raised that jumped past 3x',
+        'a raised that jumped by more than the goal',
         validate_figures,
         {'raised': 500000.0, 'goal': 170000.0, 'currency': 'EUR'},
         44155.91,
     )
     # A small drop is plausible and must still go through.
     validate_figures({'raised': 43000.0, 'goal': 170000.0, 'currency': 'EUR'}, 44155.91)
+    # So must a long gap between runs. Bounding the rise by a multiple of the
+    # last published figure would refuse this and then never recover, because a
+    # refusal writes nothing and the figure it compares against never moves.
+    validate_figures({'raised': 140000.0, 'goal': 170000.0, 'currency': 'EUR'}, 44155.91)
 
 
 def test_planning_writes_nothing():
@@ -147,9 +181,12 @@ def test_planning_reports_a_file_it_cannot_use():
         broken.write_text('{not json', encoding='utf-8')
         expect_error('a file that is not JSON', plan_update, str(broken), figures)
 
-        # Valid JSON, but not the shape we index into.
+        # Valid JSON, but not the shape we index into. The last one is the news
+        # item itself being a scalar, which reaches the update rather than the
+        # lookup, so it fails differently.
         for name, content in (('list.json', '[]'), ('scalar.json', '5'),
-                              ('news-list.json', '{"news": []}')):
+                              ('news-list.json', '{"news": []}'),
+                              ('item.json', '{"news": {"%s": 5}}' % NEWS_ID)):
             wrong_shape = pathlib.Path(directory) / name
             wrong_shape.write_text(content, encoding='utf-8')
             expect_error(f'{content} at the top level', plan_update,
@@ -164,33 +201,90 @@ def test_planning_reports_a_file_it_cannot_use():
 
 
 def test_a_bad_third_file_leaves_the_first_two_untouched():
-    """The behaviour the maintainer asked about, end to end.
+    """The behaviour the maintainer asked about, through the real write path.
 
-    Planning all three before writing any is what makes this pass. Writing each
-    file as it is planned would leave the first two already changed.
+    This calls `publish`, which is all `main` does, so writing each file as it
+    is planned would fail here instead of passing quietly.
     """
     figures = {'currency': 'EUR', 'goal': 170000.0, 'raised': 44155.91}
-    good = json.dumps({'news': {NEWS_ID: {'url': 'https://example.org'}}})
 
     with tempfile.TemporaryDirectory() as directory:
-        paths = []
-        for name in ('android.json', 'ios.json'):
-            path = pathlib.Path(directory) / name
-            path.write_text(good, encoding='utf-8')
-            paths.append(str(path))
+        paths = [a_tagline_file(directory, name)
+                 for name in ('android.json', 'ios.json')]
+        before = [pathlib.Path(path).read_text(encoding='utf-8') for path in paths]
+
         broken = pathlib.Path(directory) / 'web.json'
         broken.write_text('{not json', encoding='utf-8')
         paths.append(str(broken))
 
-        try:
-            {path: plan_update(path, figures) for path in paths}
-        except FigureError:
-            pass
-        else:
-            raise AssertionError('the broken third file should have been refused')
+        expect_error('a broken third file', publish, figures, paths)
 
-        for path in paths[:2]:
-            assert pathlib.Path(path).read_text(encoding='utf-8') == good, path
+        for path, original in zip(paths, before):
+            assert pathlib.Path(path).read_text(encoding='utf-8') == original, path
+
+
+def test_takes_the_highest_previously_published_figure():
+    with tempfile.TemporaryDirectory() as directory:
+        paths = [
+            a_tagline_file(directory, 'android.json', raised=100.0),
+            a_tagline_file(directory, 'ios.json', raised=44155.91),
+            a_tagline_file(directory, 'web.json', raised=44155.91),
+        ]
+        # The first file has drifted. Comparing against it would let the other
+        # two be halved without the drop guard noticing.
+        assert previous_raised(paths) == 44155.91
+
+
+def test_says_so_when_there_is_no_baseline():
+    with tempfile.TemporaryDirectory() as directory:
+        path = a_tagline_file(directory, 'android.json')
+
+        stderr, sys.stderr = sys.stderr, io.StringIO()
+        try:
+            assert previous_raised([path]) is None
+            reported = sys.stderr.getvalue()
+        finally:
+            sys.stderr = stderr
+
+        # Silence here would disable the only historical guard with no trace.
+        assert 'no previously published figure' in reported, reported
+
+
+def test_knows_when_the_campaign_is_over_and_when_it_cannot_tell():
+    with tempfile.TemporaryDirectory() as directory:
+        present = a_tagline_file(directory, 'android.json')
+        assert campaign_is_published([present]) is True
+
+        gone = pathlib.Path(directory) / 'empty.json'
+        gone.write_text('{"news": {}}', encoding='utf-8')
+        assert campaign_is_published([str(gone)]) is False
+
+        # An unreadable file is not evidence that the campaign ended, so it
+        # must not be reported as "nothing to update" and exit 0.
+        broken = pathlib.Path(directory) / 'broken.json'
+        broken.write_text('{not json', encoding='utf-8')
+        expect_error('an unreadable file', campaign_is_published, [str(broken)])
+
+        wrong_shape = pathlib.Path(directory) / 'shape.json'
+        wrong_shape.write_text('{"news": 5}', encoding='utf-8')
+        expect_error('a non container news field', campaign_is_published,
+                     [str(wrong_shape)])
+
+
+def test_resolves_relative_paths_against_the_repository():
+    """A run from any directory has to find the tagline files.
+
+    Asserted by changing directory, since resolving against the caller's cwd is
+    exactly the regression this guards, and it would pass from the repo root.
+    """
+    here = os.getcwd()
+    with tempfile.TemporaryDirectory() as elsewhere:
+        try:
+            os.chdir(elsewhere)
+            for path in TAGLINE_FILES:
+                assert (REPO_ROOT / path).is_file(), path
+        finally:
+            os.chdir(here)
 
 
 def test_dry_run_writes_nothing():

--- a/tools/update_campaign_figures.py
+++ b/tools/update_campaign_figures.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Publish the live donation campaign figures into the tagline JSON files.
+
+The Donorbox API needs a paid plan, but the campaign page renders the figures
+server side, so they can be read straight out of the HTML. This writes three
+optional fields onto the campaign's news item:
+
+    "currency": "EUR"      ISO code, derived from the symbol on the page
+    "goal": 170000.0       campaign goal
+    "raised": 44155.91     raised so far
+
+Apps that do not know these fields ignore them, and the smooth-app card falls
+back to its previous look when any of them is missing, so publishing them is
+safe for every already-installed version.
+
+Nothing is written unless every figure parses and passes the sanity checks in
+`validate_figures`. A stale number is acceptable; a wrong one is not.
+
+Usage:
+    python tools/update_campaign_figures.py            # fetch and update
+    python tools/update_campaign_figures.py --dry-run  # report, change nothing
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+
+CAMPAIGN_URL = 'https://donorbox.org/help-open-food-facts-stay-afloat'
+NEWS_ID = 'donation_campaign_2026'
+TAGLINE_FILES = (
+    'prod/tagline/android/main.json',
+    'prod/tagline/ios/main.json',
+    'prod/tagline/web/main.json',
+)
+
+# Donorbox prints a symbol, the app needs an ISO code for its currency format.
+CURRENCY_BY_SYMBOL = {'€': 'EUR', '$': 'USD', '£': 'GBP'}
+
+# A parse that silently goes wrong is worse than yesterday's number, so a drop
+# larger than this is treated as a bad read rather than as refunds.
+MAX_PLAUSIBLE_DROP = 0.10
+
+USER_AGENT = (
+    'openfoodfacts-smooth-app_assets campaign figure updater '
+    '(+https://github.com/openfoodfacts/smooth-app_assets)'
+)
+
+
+class FigureError(Exception):
+    """Raised when the page cannot be read into figures worth publishing."""
+
+
+def fetch_page(url=CAMPAIGN_URL):
+    request = urllib.request.Request(url, headers={'User-Agent': USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read().decode('utf-8', errors='replace')
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as error:
+        raise FigureError(f'could not fetch {url}: {error}') from error
+
+
+def parse_amount(text):
+    """Read '44.155,91 €' or '€44,155.91' into a float.
+
+    Donorbox localises the separators, so the decimal separator is whichever of
+    '.' and ',' comes last. With only one separator present, treat it as decimal
+    only when exactly two digits follow it.
+    """
+    digits = re.sub(r'[^\d.,]', '', text)
+    if not digits:
+        raise FigureError(f'no number in {text!r}')
+
+    if ',' in digits and '.' in digits:
+        decimal = ',' if digits.rfind(',') > digits.rfind('.') else '.'
+        thousands = '.' if decimal == ',' else ','
+        digits = digits.replace(thousands, '').replace(decimal, '.')
+    elif ',' in digits:
+        digits = digits.replace(',', '.' if re.search(r',\d{2}$', digits) else '')
+    elif re.search(r'\.\d{3}$', digits):
+        # '170.000' is thousands, not a fractional part.
+        digits = digits.replace('.', '')
+
+    try:
+        return float(digits)
+    except ValueError as error:
+        raise FigureError(f'could not read a number from {text!r}') from error
+
+
+def parse_currency(text):
+    for symbol, code in CURRENCY_BY_SYMBOL.items():
+        if symbol in text:
+            return code
+    raise FigureError(f'no known currency symbol in {text!r}')
+
+
+def scrape_figures(html):
+    """Pull raised, goal and currency out of the campaign page.
+
+    `total-raised` carries an id. The goal does not: it is the one bold
+    paragraph in the same block without an id, so it is matched structurally.
+    """
+    raised_match = re.search(
+        r'id="total-raised"[^>]*>(?P<value>[^<]+)<', html
+    )
+    if raised_match is None:
+        raise FigureError('no #total-raised on the page, the markup changed')
+    raised_text = raised_match.group('value').strip()
+
+    bold = re.findall(r'<p(?P<attrs>[^>]*class="bold"[^>]*)>(?P<value>[^<]+)<', html)
+    goal_text = next(
+        (
+            value.strip()
+            for attrs, value in bold
+            if 'id=' not in attrs
+            and any(symbol in value for symbol in CURRENCY_BY_SYMBOL)
+        ),
+        None,
+    )
+    if goal_text is None:
+        raise FigureError('no goal figure on the page, the markup changed')
+
+    return {
+        'currency': parse_currency(raised_text),
+        'goal': parse_amount(goal_text),
+        'raised': parse_amount(raised_text),
+    }
+
+
+def validate_figures(figures, previous_raised=None):
+    """Refuse anything that would make the meter lie."""
+    raised, goal = figures['raised'], figures['goal']
+
+    if raised <= 0:
+        raise FigureError(f'raised must be positive, got {raised}')
+    if goal <= 0:
+        raise FigureError(f'goal must be positive, got {goal}')
+    if raised > goal * 3:
+        raise FigureError(
+            f'raised {raised} is more than three times the goal {goal}, '
+            'that is a bad parse rather than a very good week'
+        )
+    if previous_raised is not None and raised < previous_raised * (1 - MAX_PLAUSIBLE_DROP):
+        raise FigureError(
+            f'raised dropped from {previous_raised} to {raised}, more than '
+            f'{MAX_PLAUSIBLE_DROP:.0%}, refusing to publish it'
+        )
+
+
+def update_file(path, figures, dry_run=False):
+    """Write the figures onto the campaign's news item. Returns True if changed.
+
+    The files are not consistently key sorted as a whole, so the document is
+    dumped in its original order and only this one item is sorted, which keeps
+    the diff to the lines that actually changed.
+    """
+    file = pathlib.Path(path)
+    original = file.read_text(encoding='utf-8')
+    document = json.loads(original)
+
+    try:
+        item = document['news'][NEWS_ID]
+    except KeyError as error:
+        raise FigureError(f'{path} has no news item {NEWS_ID!r}') from error
+
+    item.update(figures)
+    document['news'][NEWS_ID] = {key: item[key] for key in sorted(item)}
+
+    updated = json.dumps(document, indent=2, ensure_ascii=False) + '\n'
+    if updated == original:
+        return False
+    if not dry_run:
+        file.write_text(updated, encoding='utf-8')
+    return True
+
+
+def previous_raised(path=TAGLINE_FILES[0]):
+    try:
+        document = json.loads(pathlib.Path(path).read_text(encoding='utf-8'))
+        return document['news'][NEWS_ID].get('raised')
+    except (OSError, ValueError, KeyError):
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='report the figures without writing the files',
+    )
+    arguments = parser.parse_args()
+
+    try:
+        figures = scrape_figures(fetch_page())
+        validate_figures(figures, previous_raised())
+    except FigureError as error:
+        print(f'campaign figures not updated: {error}', file=sys.stderr)
+        return 1
+
+    print(
+        'read {raised:.2f} of {goal:.2f} {currency}'.format(**figures),
+        f'({figures["raised"] / figures["goal"]:.1%})',
+    )
+
+    changed = [path for path in TAGLINE_FILES
+               if update_file(path, figures, arguments.dry_run)]
+    if not changed:
+        print('figures unchanged, nothing to commit')
+    else:
+        verb = 'would update' if arguments.dry_run else 'updated'
+        print(f'{verb}: ' + ', '.join(changed))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/update_campaign_figures.py
+++ b/tools/update_campaign_figures.py
@@ -31,6 +31,11 @@ import urllib.request
 
 CAMPAIGN_URL = 'https://donorbox.org/help-open-food-facts-stay-afloat'
 NEWS_ID = 'donation_campaign_2026'
+
+# Paths below are resolved against the repository, not the current directory,
+# so the script works the same from anywhere. An absolute path passes through.
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
 TAGLINE_FILES = (
     'prod/tagline/android/main.json',
     'prod/tagline/ios/main.json',
@@ -40,9 +45,14 @@ TAGLINE_FILES = (
 # Donorbox prints a symbol, the app needs an ISO code for its currency format.
 CURRENCY_BY_SYMBOL = {'€': 'EUR', '$': 'USD', '£': 'GBP'}
 
-# A parse that silently goes wrong is worse than yesterday's number, so a drop
-# larger than this is treated as a bad read rather than as refunds.
+# A parse that silently goes wrong is worse than yesterday's number, so a move
+# larger than either of these is treated as a bad read rather than as a good day.
 MAX_PLAUSIBLE_DROP = 0.10
+MAX_PLAUSIBLE_RISE = 3.0
+
+# The page draws its own progress bar. Our arithmetic has to agree with it, in
+# percentage points, or one of the two numbers we read was not what we thought.
+MAX_PERCENT_DISAGREEMENT = 2.0
 
 USER_AGENT = (
     'openfoodfacts-smooth-app_assets campaign figure updater '
@@ -130,7 +140,17 @@ def scrape_figures(html):
     }
 
 
-def validate_figures(figures, previous_raised=None):
+def scrape_page_percent(html):
+    """Return the percentage the page draws in its own progress bar, or None.
+
+    This is the campaign's own arithmetic, so it is the one number on the page
+    that can contradict ours.
+    """
+    match = re.search(r'\.meter\s*\{[^}]*width:\s*(?P<value>[\d.]+)%', html)
+    return float(match.group('value')) if match else None
+
+
+def validate_figures(figures, previous_raised=None, page_percent=None):
     """Refuse anything that would make the meter lie."""
     raised, goal = figures['raised'], figures['goal']
 
@@ -143,15 +163,29 @@ def validate_figures(figures, previous_raised=None):
             f'raised {raised} is more than three times the goal {goal}, '
             'that is a bad parse rather than a very good week'
         )
-    if previous_raised is not None and raised < previous_raised * (1 - MAX_PLAUSIBLE_DROP):
-        raise FigureError(
-            f'raised dropped from {previous_raised} to {raised}, more than '
-            f'{MAX_PLAUSIBLE_DROP:.0%}, refusing to publish it'
-        )
+    if previous_raised is not None:
+        if raised < previous_raised * (1 - MAX_PLAUSIBLE_DROP):
+            raise FigureError(
+                f'raised dropped from {previous_raised} to {raised}, more than '
+                f'{MAX_PLAUSIBLE_DROP:.0%}, refusing to publish it'
+            )
+        if raised > previous_raised * MAX_PLAUSIBLE_RISE:
+            raise FigureError(
+                f'raised jumped from {previous_raised} to {raised}, more than '
+                f'{MAX_PLAUSIBLE_RISE:g}x, refusing to publish it'
+            )
+    if page_percent is not None:
+        computed = raised / goal * 100
+        if abs(computed - page_percent) > MAX_PERCENT_DISAGREEMENT:
+            raise FigureError(
+                f'we read {raised} of {goal}, i.e. {computed:.1f}%, but the '
+                f'page draws {page_percent:.1f}%. One of the two figures is '
+                'not the one we think it is'
+            )
 
 
 def plan_update(path, figures):
-    """Return the new content for [path], or None when it would not change.
+    """Return the new content for `path`, or None when it would not change.
 
     Nothing is written here: every file is planned before any is written, so a
     file that cannot be read leaves the others untouched rather than half of
@@ -162,10 +196,11 @@ def plan_update(path, figures):
     the diff to the lines that actually changed.
     """
     try:
-        original = pathlib.Path(path).read_text(encoding='utf-8')
+        original = (REPO_ROOT / path).read_text(encoding='utf-8')
         document = json.loads(original)
         item = document['news'][NEWS_ID]
-    except (OSError, ValueError) as error:
+    except (OSError, ValueError, TypeError) as error:
+        # TypeError: valid JSON, but not the object shape we index into.
         raise FigureError(f'could not read {path}: {error}') from error
     except KeyError as error:
         raise FigureError(f'{path} has no news item {NEWS_ID!r}') from error
@@ -177,12 +212,62 @@ def plan_update(path, figures):
     return None if updated == original else updated
 
 
-def previous_raised(path=TAGLINE_FILES[0]):
-    try:
-        document = json.loads(pathlib.Path(path).read_text(encoding='utf-8'))
-        return document['news'][NEWS_ID].get('raised')
-    except (OSError, ValueError, KeyError):
+def previous_raised(paths=TAGLINE_FILES):
+    """Highest `raised` already published, across every file we are about to write.
+
+    The highest, not the first: the files can drift apart after a hand edit, and
+    the drop guard is only worth having if it compares against the largest
+    figure any of them currently shows.
+    """
+    published = []
+    for path in paths:
+        try:
+            document = json.loads((REPO_ROOT / path).read_text(encoding='utf-8'))
+            value = document['news'][NEWS_ID].get('raised')
+        except (OSError, ValueError, TypeError, KeyError):
+            continue
+        if isinstance(value, (int, float)):
+            published.append(value)
+
+    if not published:
+        print(
+            'no previously published figure found, so the plausibility check '
+            'against it is skipped for this run',
+            file=sys.stderr,
+        )
         return None
+    return max(published)
+
+
+def campaign_is_published(paths=TAGLINE_FILES):
+    """True while at least one tagline file still carries the campaign item.
+
+    Once the campaign is over the item is removed from the feed, and this run
+    has nothing left to do. That is a clean exit, not a failure: a scheduled job
+    that goes red every morning forever gets deleted.
+    """
+    for path in paths:
+        try:
+            document = json.loads((REPO_ROOT / path).read_text(encoding='utf-8'))
+        except (OSError, ValueError):
+            continue
+        if isinstance(document, dict) and NEWS_ID in document.get('news', {}):
+            return True
+    return False
+
+
+def apply_updates(plans, dry_run=False):
+    """Write every planned file. Returns the paths that changed.
+
+    Split out of `main` so the all-or-nothing ordering can be tested without a
+    network call: nothing here decides anything, it only writes what planning
+    already produced.
+    """
+    changed = [path for path, content in plans.items() if content is not None]
+    if not dry_run:
+        for path in changed:
+            (REPO_ROOT / path).write_text(plans[path], encoding='utf-8')
+    return changed
 
 
 def main():
@@ -194,9 +279,14 @@ def main():
     )
     arguments = parser.parse_args()
 
+    if not campaign_is_published():
+        print(f'no {NEWS_ID} item in the tagline files, nothing to update')
+        return 0
+
     try:
-        figures = scrape_figures(fetch_page())
-        validate_figures(figures, previous_raised())
+        html = fetch_page()
+        figures = scrape_figures(html)
+        validate_figures(figures, previous_raised(), scrape_page_percent(html))
         plans = {path: plan_update(path, figures) for path in TAGLINE_FILES}
     except FigureError as error:
         print(f'campaign figures not updated: {error}', file=sys.stderr)
@@ -207,11 +297,7 @@ def main():
         f'({figures["raised"] / figures["goal"]:.1%})',
     )
 
-    changed = [path for path, content in plans.items() if content is not None]
-    if not arguments.dry_run:
-        for path in changed:
-            pathlib.Path(path).write_text(plans[path], encoding='utf-8')
-
+    changed = apply_updates(plans, arguments.dry_run)
     if not changed:
         print('figures unchanged, nothing to commit')
     else:

--- a/tools/update_campaign_figures.py
+++ b/tools/update_campaign_figures.py
@@ -162,7 +162,12 @@ def scrape_page_percent(html):
 
 
 def validate_figures(figures, previous_raised=None, page_percent=None):
-    """Refuse anything that would make the meter lie."""
+    """Refuse anything that would make the meter lie.
+
+    Every refusal leaves the published figures alone, so a run that is wrongly
+    refused stays refused until someone corrects the JSON by hand. The bounds
+    below are set wide enough that only a misparse should reach them.
+    """
     raised, goal = figures['raised'], figures['goal']
 
     if raised <= 0:
@@ -190,17 +195,27 @@ def validate_figures(figures, previous_raised=None, page_percent=None):
                 f'raised jumped from {previous_raised} to {raised}, i.e. by '
                 f'more than the whole {goal} goal in one run, refusing it'
             )
-    # A meter pinned at 100 has been clamped, so it no longer states a ratio and
-    # cannot corroborate an over-funded campaign. `raised > goal * 3` still caps
-    # that case.
-    if page_percent is not None and page_percent < 100:
-        computed = raised / goal * 100
-        if abs(computed - page_percent) > MAX_PERCENT_DISAGREEMENT:
-            raise FigureError(
-                f'we read {raised} of {goal}, i.e. {computed:.1f}%, but the '
-                f'page draws {page_percent:.1f}%. One of the two figures is '
-                'not the one we think it is'
-            )
+    if page_percent is not None:
+        if page_percent >= 100:
+            # Clamped, so it no longer states a ratio. It does still say the
+            # goal was reached, and skipping the check outright would let a
+            # misparsed goal through exactly when nothing else can catch one.
+            # Same tolerance the other branch gets: the evidence that Donorbox
+            # floors rather than rounds is one observation, and a wrong refusal
+            # here would wedge the run at the campaign's best moment.
+            if raised < goal * (1 - MAX_PERCENT_DISAGREEMENT / 100):
+                raise FigureError(
+                    f'the page draws a full meter, so {raised} should have '
+                    f'reached the {goal} goal. One of the two is wrong'
+                )
+        else:
+            computed = raised / goal * 100
+            if abs(computed - page_percent) > MAX_PERCENT_DISAGREEMENT:
+                raise FigureError(
+                    f'we read {raised} of {goal}, i.e. {computed:.1f}%, but the '
+                    f'page draws {page_percent:.1f}%. One of the two figures is '
+                    'not the one we think it is'
+                )
 
 
 def plan_update(path, figures):

--- a/tools/update_campaign_figures.py
+++ b/tools/update_campaign_figures.py
@@ -45,13 +45,14 @@ TAGLINE_FILES = (
 # Donorbox prints a symbol, the app needs an ISO code for its currency format.
 CURRENCY_BY_SYMBOL = {'€': 'EUR', '$': 'USD', '£': 'GBP'}
 
-# A parse that silently goes wrong is worse than yesterday's number, so a move
-# larger than either of these is treated as a bad read rather than as a good day.
+# A parse that silently goes wrong is worse than yesterday's number, so a drop
+# larger than this is treated as a bad read rather than as refunds.
 MAX_PLAUSIBLE_DROP = 0.10
-MAX_PLAUSIBLE_RISE = 3.0
 
 # The page draws its own progress bar. Our arithmetic has to agree with it, in
 # percentage points, or one of the two numbers we read was not what we thought.
+# Donorbox floors its width, so about 1 of these 2 points is its rounding rather
+# than slack. Every misparse seen so far lands at least 4 points out.
 MAX_PERCENT_DISAGREEMENT = 2.0
 
 USER_AGENT = (
@@ -141,13 +142,23 @@ def scrape_figures(html):
 
 
 def scrape_page_percent(html):
-    """Return the percentage the page draws in its own progress bar, or None.
+    """Return the percentage the page draws in its own progress bar.
 
     This is the campaign's own arithmetic, so it is the one number on the page
     that can contradict ours.
+
+    Missing it is an error rather than a skipped check. The whole point of this
+    number is to catch a run where the markup moved under us, so treating
+    "the markup moved" as "check not applicable" would disable it exactly when
+    it is needed.
     """
     match = re.search(r'\.meter\s*\{[^}]*width:\s*(?P<value>[\d.]+)%', html)
-    return float(match.group('value')) if match else None
+    if match is None:
+        raise FigureError(
+            'no progress bar width on the page, so nothing corroborates the '
+            'figures we read. The markup changed'
+        )
+    return float(match.group('value'))
 
 
 def validate_figures(figures, previous_raised=None, page_percent=None):
@@ -169,12 +180,20 @@ def validate_figures(figures, previous_raised=None, page_percent=None):
                 f'raised dropped from {previous_raised} to {raised}, more than '
                 f'{MAX_PLAUSIBLE_DROP:.0%}, refusing to publish it'
             )
-        if raised > previous_raised * MAX_PLAUSIBLE_RISE:
+        # Bounded by the goal rather than by a multiple of the previous figure.
+        # A multiple would be self-locking: once it refuses, nothing is written,
+        # so the figure it compares against never advances and every later run
+        # refuses too. Raising more than the entire goal in one day is the
+        # impossible part, and that does not go stale.
+        if raised - previous_raised > goal:
             raise FigureError(
-                f'raised jumped from {previous_raised} to {raised}, more than '
-                f'{MAX_PLAUSIBLE_RISE:g}x, refusing to publish it'
+                f'raised jumped from {previous_raised} to {raised}, i.e. by '
+                f'more than the whole {goal} goal in one run, refusing it'
             )
-    if page_percent is not None:
+    # A meter pinned at 100 has been clamped, so it no longer states a ratio and
+    # cannot corroborate an over-funded campaign. `raised > goal * 3` still caps
+    # that case.
+    if page_percent is not None and page_percent < 100:
         computed = raised / goal * 100
         if abs(computed - page_percent) > MAX_PERCENT_DISAGREEMENT:
             raise FigureError(
@@ -199,17 +218,25 @@ def plan_update(path, figures):
         original = (REPO_ROOT / path).read_text(encoding='utf-8')
         document = json.loads(original)
         item = document['news'][NEWS_ID]
-    except (OSError, ValueError, TypeError) as error:
-        # TypeError: valid JSON, but not the object shape we index into.
+        item.update(figures)
+        document['news'][NEWS_ID] = {key: item[key] for key in sorted(item)}
+        updated = json.dumps(document, indent=2, ensure_ascii=False) + '\n'
+    except (OSError, ValueError, TypeError, AttributeError) as error:
+        # Anything but a readable object of the shape we index into.
         raise FigureError(f'could not read {path}: {error}') from error
     except KeyError as error:
         raise FigureError(f'{path} has no news item {NEWS_ID!r}') from error
 
-    item.update(figures)
-    document['news'][NEWS_ID] = {key: item[key] for key in sorted(item)}
-
-    updated = json.dumps(document, indent=2, ensure_ascii=False) + '\n'
     return None if updated == original else updated
+
+
+def plan_all(paths, figures):
+    """Plan every file before any of them is written.
+
+    This is the all-or-nothing step: one unreadable file raises before a single
+    write has happened, so the others keep the figures they had.
+    """
+    return {path: plan_update(path, figures) for path in paths}
 
 
 def previous_raised(paths=TAGLINE_FILES):
@@ -242,32 +269,44 @@ def previous_raised(paths=TAGLINE_FILES):
 def campaign_is_published(paths=TAGLINE_FILES):
     """True while at least one tagline file still carries the campaign item.
 
-    Once the campaign is over the item is removed from the feed, and this run
-    has nothing left to do. That is a clean exit, not a failure: a scheduled job
-    that goes red every morning forever gets deleted.
+    Once the campaign is over the item is removed from the feed and this run has
+    nothing left to do, which is a clean exit rather than a failure: a scheduled
+    job that goes red every morning forever gets deleted.
+
+    A file we cannot read is not evidence of that, so it raises. Otherwise three
+    corrupt files would report "the campaign is over" and exit 0 for good.
     """
+    published = False
     for path in paths:
         try:
             document = json.loads((REPO_ROOT / path).read_text(encoding='utf-8'))
-        except (OSError, ValueError):
-            continue
-        if isinstance(document, dict) and NEWS_ID in document.get('news', {}):
-            return True
-    return False
+            published = published or NEWS_ID in document['news']
+        except (OSError, ValueError, TypeError, KeyError) as error:
+            raise FigureError(f'could not read {path}: {error}') from error
+    return published
 
 
 def apply_updates(plans, dry_run=False):
-    """Write every planned file. Returns the paths that changed.
-
-    Split out of `main` so the all-or-nothing ordering can be tested without a
-    network call: nothing here decides anything, it only writes what planning
-    already produced.
-    """
+    """Write every planned file. Returns the paths that changed."""
     changed = [path for path, content in plans.items() if content is not None]
     if not dry_run:
         for path in changed:
-            (REPO_ROOT / path).write_text(plans[path], encoding='utf-8')
+            # newline='' writes the '\n' we built rather than os.linesep, so the
+            # bytes are the same whichever platform runs this.
+            (REPO_ROOT / path).write_text(
+                plans[path], encoding='utf-8', newline=''
+            )
     return changed
+
+
+def publish(figures, paths=TAGLINE_FILES, dry_run=False):
+    """Plan every file, then write. Returns the paths that changed.
+
+    This is the whole write path, and `main` does nothing else, so a test can
+    drive the real sequencing without a network call. Keep it that way: the
+    ordering only holds because planning finishes before writing starts.
+    """
+    return apply_updates(plan_all(paths, figures), dry_run)
 
 
 def main():
@@ -279,25 +318,23 @@ def main():
     )
     arguments = parser.parse_args()
 
-    if not campaign_is_published():
-        print(f'no {NEWS_ID} item in the tagline files, nothing to update')
-        return 0
-
     try:
+        if not campaign_is_published():
+            print(f'no {NEWS_ID} item in the tagline files, nothing to update')
+            return 0
+
         html = fetch_page()
         figures = scrape_figures(html)
         validate_figures(figures, previous_raised(), scrape_page_percent(html))
-        plans = {path: plan_update(path, figures) for path in TAGLINE_FILES}
+        print(
+            'read {raised:.2f} of {goal:.2f} {currency}'.format(**figures),
+            f'({figures["raised"] / figures["goal"]:.1%})',
+        )
+        changed = publish(figures, TAGLINE_FILES, arguments.dry_run)
     except FigureError as error:
         print(f'campaign figures not updated: {error}', file=sys.stderr)
         return 1
 
-    print(
-        'read {raised:.2f} of {goal:.2f} {currency}'.format(**figures),
-        f'({figures["raised"] / figures["goal"]:.1%})',
-    )
-
-    changed = apply_updates(plans, arguments.dry_run)
     if not changed:
         print('figures unchanged, nothing to commit')
     else:

--- a/tools/update_campaign_figures.py
+++ b/tools/update_campaign_figures.py
@@ -150,19 +150,23 @@ def validate_figures(figures, previous_raised=None):
         )
 
 
-def update_file(path, figures, dry_run=False):
-    """Write the figures onto the campaign's news item. Returns True if changed.
+def plan_update(path, figures):
+    """Return the new content for [path], or None when it would not change.
+
+    Nothing is written here: every file is planned before any is written, so a
+    file that cannot be read leaves the others untouched rather than half of
+    them updated.
 
     The files are not consistently key sorted as a whole, so the document is
     dumped in its original order and only this one item is sorted, which keeps
     the diff to the lines that actually changed.
     """
-    file = pathlib.Path(path)
-    original = file.read_text(encoding='utf-8')
-    document = json.loads(original)
-
     try:
+        original = pathlib.Path(path).read_text(encoding='utf-8')
+        document = json.loads(original)
         item = document['news'][NEWS_ID]
+    except (OSError, ValueError) as error:
+        raise FigureError(f'could not read {path}: {error}') from error
     except KeyError as error:
         raise FigureError(f'{path} has no news item {NEWS_ID!r}') from error
 
@@ -170,11 +174,7 @@ def update_file(path, figures, dry_run=False):
     document['news'][NEWS_ID] = {key: item[key] for key in sorted(item)}
 
     updated = json.dumps(document, indent=2, ensure_ascii=False) + '\n'
-    if updated == original:
-        return False
-    if not dry_run:
-        file.write_text(updated, encoding='utf-8')
-    return True
+    return None if updated == original else updated
 
 
 def previous_raised(path=TAGLINE_FILES[0]):
@@ -197,6 +197,7 @@ def main():
     try:
         figures = scrape_figures(fetch_page())
         validate_figures(figures, previous_raised())
+        plans = {path: plan_update(path, figures) for path in TAGLINE_FILES}
     except FigureError as error:
         print(f'campaign figures not updated: {error}', file=sys.stderr)
         return 1
@@ -206,8 +207,11 @@ def main():
         f'({figures["raised"] / figures["goal"]:.1%})',
     )
 
-    changed = [path for path in TAGLINE_FILES
-               if update_file(path, figures, arguments.dry_run)]
+    changed = [path for path, content in plans.items() if content is not None]
+    if not arguments.dry_run:
+        for path in changed:
+            pathlib.Path(path).write_text(plans[path], encoding='utf-8')
+
     if not changed:
         print('figures unchanged, nothing to commit')
     else:


### PR DESCRIPTION
Closes #72.

@teolemon asked whether we could just read the figures from https://donorbox.org/help-open-food-facts-stay-afloat, and we can: the API needs a paid plan, but that page renders the numbers server side. So this reads them from the HTML and commits them once a day.

@monsieurtanuki suggested populating them by hand weekly as a stopgap. That still works and is documented, this just means nobody has to remember.

### What

- `tools/update_campaign_figures.py` reads `raised`, `goal` and the currency from the campaign page and writes them onto the `donation_campaign_2026` news item in all three tagline files.
- A daily workflow runs it, validates the files with the existing `tests/validate_tagline_json.py`, and commits only when the figures have moved. `workflow_dispatch` is on, so you can run it once by hand before trusting the schedule.
- The three current figures are seeded in this PR, so the card works the moment it merges rather than waiting for the first scheduled run.
- A short README section explaining the fields, in the same style as the rest of that file.

### Why daily and not more often

The app caches the tagline feed for a day, so anything faster would add requests without the number changing on anyone's screen. The total moves by a few euros a day.

### Safety

- **Nothing here can break an installed app.** The parser in the app ignores JSON keys it does not know, and the donation card falls back to exactly its current look when any of the three fields is missing. So this can merge before, after or without the app side (openfoodfacts/smooth-app#7667).
- **The script refuses to publish a number it is not sure about.** Both values must be positive, `raised` must not be wildly above `goal`, and a drop of more than 10% against the published figure is rejected as a bad parse rather than accepted as refunds. On any failure it writes nothing and exits non-zero, so the previous figures stay. A stale number is better than a wrong one.
- Amount parsing handles both localisations Donorbox serves, `44.155,91 €` and `$170,000`.
- No new dependencies, standard library only.

### What I could not test from here

The script is verified against the live page (it reads `44155.91` of `170000.00 EUR`, 26.0%) and `tests/validate_tagline_json.py` passes on the result. The **workflow itself has not executed**, because scheduled and dispatchable workflows only run from a repository's default branch, not from a fork's PR branch. That is what `workflow_dispatch` is there for: one manual run after merge will confirm it.

### One thing I deliberately did not change

`donation_campaign_2026` has `end_date: 2027-01-31`, which in this feed means "stop serving this item" rather than "the campaign deadline". With today's date that reads as "5 months left" on the card, which is sensible, so nothing needs changing. I am flagging it only because the two meanings can drift apart: if the campaign's real deadline is much earlier than the date the card should stop showing, the line would overstate the time left. The app side already suppresses the clause when the span is implausibly long. Changing the date is your editorial call, so I have left it alone.
